### PR TITLE
Add `falcon_cors`  to spacy-annotator requirements.txt

### DIFF
--- a/spacy-annotator/requirements.txt
+++ b/spacy-annotator/requirements.txt
@@ -2,3 +2,4 @@ falcon
 spacy
 pytest
 gunicorn
+falcon_cors


### PR DESCRIPTION
fix installation error.