### PR TITLE
Remove parallelism and reduce RAM usage in plain_word_freqs.py

### DIFF
--- a/training/plain_word_freqs.py
+++ b/training/plain_word_freqs.py
@@ -4,9 +4,10 @@ from __future__ import unicode_literals
 import codecs
 import glob
 from collections import Counter
+import warnings
 
+from future.utils import iteritems
 import plac
-from multiprocessing import Pool
 from tqdm import tqdm
 
 
@@ -17,16 +18,17 @@ def count_words(fpath):
     return counter
 
 
-def main(input_glob, out_loc, workers=4):
-    p = Pool(processes=workers)
-    counts = p.map(count_words, tqdm(list(glob.glob(input_glob))))
+def main(input_glob, out_loc, workers=None):
+    if workers is not None:
+        warnings.warn("workers argument is no longer needed", DeprecationWarning)
     df_counts = Counter()
     word_counts = Counter()
-    for wc in tqdm(counts):
+    for fpath in tqdm(glob.glob(input_glob)):
+        wc = count_words(fpath)
         df_counts.update(wc.keys())
         word_counts.update(wc)
     with codecs.open(out_loc, "w", encoding="utf8") as f:
-        for word, df in df_counts.iteritems():
+        for word, df in iteritems(df_counts):
             f.write(u"{freq}\t{df}\t{word}\n".format(word=repr(word), df=df, freq=word_counts[word]))
 
 


### PR DESCRIPTION
Load the files in the program directly rather than using separate
processes.  This is unnecessary: for small corpus the gain is not
sufficient to compensate the cost of process creation and IPC.  For
large corpus the parallelism causes unwanted disk movement and hurts
performance.

Once the counts for a file is computed, merge it to the running counts
and discard the file counts.  This is very important for large corpus,
otherwise the dicts for the large number of files easily fill all the
available memory and cause the machine to thrash.

This also makes the display of tqdm much more smooth.

Signed-off-by: Isaac To <isaac.to@gmail.com>